### PR TITLE
Merge options recursively

### DIFF
--- a/js/jquery.selectric.js
+++ b/js/jquery.selectric.js
@@ -38,7 +38,7 @@
         return s;
       },
       init = function(element, options) {
-        var options = $.extend({
+        var options = $.extend(true, {
               onOpen: $.noop,
               onClose: $.noop,
               onChange: $.noop,


### PR DESCRIPTION
Since there is the `customClass` object inside the options, it would make sense to merge them recursively. Otherwise you're not able to only provide `prefix` for example, because `customClass.postfixes.split(' ')` will throw an error then (as `postfixes` is `undefined`).
