### PR TITLE
Viewport might not always be the window itself

### DIFF
--- a/js/jquery.selectric.js
+++ b/js/jquery.selectric.js
@@ -51,6 +51,7 @@
               openOnHover: false,
               expandToItemText: false,
               responsive: false,
+              viewportHeight: function(element) { return $(window).height(); },
               customClass: {
                 prefix: 'selectric',
                 postfixes: 'Input Items Open Disabled TempShow HideSelect Wrapper Hover Responsive',
@@ -285,7 +286,7 @@
         // Detect is the options box is inside the window
         function _isInViewport() {
             _calculateOptionsDimensions();
-            $items.css('top', ($outerWrapper.offset().top + $outerWrapper.outerHeight() + itemsHeight > $win.scrollTop() + $win.height()) ? -itemsHeight : '');
+            $items.css('top', ($outerWrapper.offset().top + $outerWrapper.outerHeight() + itemsHeight > $win.scrollTop() + options.viewportHeight($items)) ? -itemsHeight : '');
         }
 
         // Close the select options box

--- a/js/jquery.selectric.js
+++ b/js/jquery.selectric.js
@@ -10,6 +10,7 @@
  *   /'
  *
  * Selectric Ϟ v1.6.7 - http://lcdsantos.github.io/jQuery-Selectric/
+ * Forked by Mardaneus86 - https://github.com/Mardaneus86/jQuery-Selectric/
  *
  * Copyright (c) 2014 Leonardo Santos; Dual licensed: MIT/GPL
  *


### PR DESCRIPTION
The viewport is not always the window, but sometimes a portion of a window. For example when you are working in a single page application, it might be a specific block element on a page.

With this change, it is possible to introduce a different calculation method for the viewport height through the viewportHeight options parameter. This option is a function that takes the items as its argument.

Potential use case when a view class block element is used as the viewport that is smaller than the window:
```javascript
$(element).find('select').selectric({
    viewportHeight: function(element)
    {
        var parentView = element.closest(".view");
        if (parentView.length > 0) 
        {
            if (parentView.height() <= $(window).height())
            {
                return parentView.height();
            }
        }
        return $(window).height();
    }
};
```

Please review.