### PR TITLE
fix counting options within template element (polymer or x-tag)

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -159,7 +159,7 @@
         function _populate() {
           _this.items = [];
 
-          var $options = $original.children(),
+          var $options = $original.children('option'),
               _$li = '<ul>',
               selectedIndex = $options.filter(':selected').index(),
               currIndex = 0;


### PR DESCRIPTION
With [polymer from Google](https://www.polymer-project.org/0.5/docs/polymer/binding-types.html#iterative-templates)  following code are valid and rendering by browsers. This caused wrong behavior ( wrong options length).
```
<select id="dropbox">
  <template repeat="{{key in values}}">
    <option value="{{key}}">{{values[key]}}</option>
  </template>
</select>
```