### PR TITLE
toggle hover class issue 

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -238,13 +238,19 @@
             isEnabled = true;
 
             // Not disabled, so... Removing disabled class and bind hover
-            $outerWrapper.removeClass(_this.classes.disabled).on('mouseenter' + bindSufix + ' mouseleave' + bindSufix, function(e) {
-              $(this).toggleClass(_this.classes.hover);
-
+            $outerWrapper.removeClass(_this.classes.disabled).on('mouseenter' + bindSufix, function(e) {
+              $(this).addClass(_this.classes.hover);
               // Delay close effect when openOnHover is true
               if ( _this.options.openOnHover ) {
                 clearTimeout(_this.closeTimer);
-                e.type == 'mouseleave' ? _this.closeTimer = setTimeout(_close, _this.options.hoverIntentTimeout) : _open();
+                _open();
+              }
+            }).on( 'mouseleave' + bindSufix, function(e){
+              $(this).removeClass(_this.classes.hover);
+              // Delay close effect when openOnHover is true
+              if ( _this.options.openOnHover ) {
+                clearTimeout(_this.closeTimer);
+                _this.closeTimer = setTimeout(_close, _this.options.hoverIntentTimeout);
               }
             });
 


### PR DESCRIPTION
Using toggleClass causes hover class to stay active when public 'refresh' is triggered when the mouse is over the element.