### PR TITLE
Fix keyboard navigation for opt group options (#154)

### DIFF
--- a/public/jquery.selectric.js
+++ b/public/jquery.selectric.js
@@ -9,7 +9,7 @@
  *    /,'
  *   /'
  *
- * Selectric ϟ v1.11.0 (Nov 20 2016) - http://lcdsantos.github.io/jQuery-Selectric/
+ * Selectric ϟ v1.11.0 (Dec 15 2016) - http://lcdsantos.github.io/jQuery-Selectric/
  *
  * Copyright (c) 2016 Leonardo Santos; MIT License
  *
@@ -699,11 +699,11 @@
         }
 
         if ( isPrevKey ) {
-          goToItem = _this.utils.previousEnabledItem(_this.items, idx);
+          goToItem = _this.utils.previousEnabledItem(_this.lookupItems, idx);
         }
 
         if ( isNextKey ) {
-          goToItem = _this.utils.nextEnabledItem(_this.items, idx);
+          goToItem = _this.utils.nextEnabledItem(_this.lookupItems, idx);
         }
 
         _this.highlight(goToItem);

--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -682,11 +682,11 @@
         }
 
         if ( isPrevKey ) {
-          goToItem = _this.utils.previousEnabledItem(_this.items, idx);
+          goToItem = _this.utils.previousEnabledItem(_this.lookupItems, idx);
         }
 
         if ( isNextKey ) {
-          goToItem = _this.utils.nextEnabledItem(_this.items, idx);
+          goToItem = _this.utils.nextEnabledItem(_this.lookupItems, idx);
         }
 
         _this.highlight(goToItem);


### PR DESCRIPTION
Using lookupItems allows use of keyboard navigation for optgroup options while retaining keyboard navigation on non-optgroup dropdown.

[Issue #154](https://github.com/lcdsantos/jQuery-Selectric/issues/154)