### PR TITLE
Set line-height on .button

### DIFF
--- a/public/selectric.css
+++ b/public/selectric.css
@@ -42,6 +42,7 @@
   top: 0;
   width: 38px;
   height: 38px;
+  line-height: 38px;
   background-color: #F8f8f8;
   color: #BBB;
   text-align: center;

--- a/src/selectric.scss
+++ b/src/selectric.scss
@@ -46,6 +46,7 @@ $selectric-font-size:       12px !default;                                      
     top: 0;
     width: $selectric-inner-height;
     height: $selectric-inner-height;
+    line-height: $selectric-inner-height;
     background-color: $selectric-btn-bg-color;
     color: $selectric-secondary-color;
     text-align: center;


### PR DESCRIPTION
Used same `$selectric-inner-height` variable for line-height, to center the caret icon vertically (when not using pseudo triangle).