### PR TITLE
Changing the conditions of replacement in toDash

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -170,7 +170,7 @@
        * @return {string}       The string transformed to dash-case.
        */
       toDash: function(str) {
-        return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+        return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
       },
 
       /**


### PR DESCRIPTION
If string from customClass prefix ends with a number does not work
replacement regexp. For example "classname2" -> classname2wrapper
instead of classname2-wrapper