### PR TITLE
Fix to bug #180 - Stop on first value from keypress not the last

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -628,7 +628,9 @@
               // Search in select options
               $.each(_this.items, function(i, elm) {
                 if ( !elm.disabled && searchRegExp.test(elm.text) || searchRegExp.test(elm.slug) ) {
-                  _this.highlight(i);
+
+                  // Stop on the first option from the value made on keypress.
+                  _this.highlight(i).first();
                   return;
                 }
               });


### PR DESCRIPTION
Currently when you click a value using the keyboard it's looping through all the instances that match and then highlighting the last item from that value. This makes it challenging to use this when using it as a state select menu, as when you click on the letter "C" it selects Connecticut instead of California like it should.

Adding this logic stops it at the first value. 