### PR TITLE
Alternative texts for search using the option attribute data-alt

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -472,6 +472,7 @@
         className : $elm.prop('class'),
         text      : $elm.html(),
         slug      : $.trim(_this.utils.replaceDiacritics($elm.html())),
+        alt       : $elm.attr('data-alt'),
         selected  : $elm.prop('selected'),
         disabled  : isDisabled
       };
@@ -627,9 +628,25 @@
             if ( val.length ) {
               // Search in select options
               $.each(_this.items, function(i, elm) {
-                if ( !elm.disabled && searchRegExp.test(elm.text) || searchRegExp.test(elm.slug) ) {
+                if (elm.disabled) {
+                  return;
+                }
+                if (searchRegExp.test(elm.text) || searchRegExp.test(elm.slug)) {
                   _this.highlight(i);
                   return;
+                }
+                if (!elm.alt) {
+                  return;
+                }
+                var altItems = elm.alt.split('|');
+                for (var ai = 0; ai < altItems.length; ai++) {
+                  if (!altItems[ai]) {
+                    break;
+                  }
+                  if (searchRegExp.test(altItems[ai].trim())) {
+                    _this.highlight(i);
+                    return;
+                  }
                 }
               });
             }

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -80,6 +80,24 @@ describe('basic suite', function() {
     expect(select.val()).toBe('banana');
   });
 
+  it('should search alternative text', function () {
+    $('.selectric-input').val('alt banana').trigger('input');
+    $('.selectric-items').find('.highlighted').click();
+    expect(select.val()).toBe('banana');
+  });
+
+  it('should search alternative text with separator', function () {
+    $('.selectric-input').val('altberry').trigger('input');
+    $('.selectric-items').find('.highlighted').click();
+    expect(select.val()).toBe('bilberry');
+  });
+
+  it('should search alternative text with separator 2', function () {
+    $('.selectric-input').val('another berry').trigger('input');
+    $('.selectric-items').find('.highlighted').click();
+    expect(select.val()).toBe('bilberry');
+  });  
+
   it('highlight() should return undefined if index is undefined', function () {
     expect(select.data('selectric').highlight(undefined)).toBe(undefined);
   });

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -80,23 +80,44 @@ describe('basic suite', function() {
     expect(select.val()).toBe('banana');
   });
 
+  it('should not search a disabled option', function() {
+    select.find('option:eq(4)').prop('disabled', 'disabled');
+    select.selectric('refresh');
+    $('.selectric-input').val('banana').trigger('input');
+    $('.selectric-items').find('.highlighted').lenght;
+    expect($('.selectric-items').find('.highlighted').length).toBe(0);
+  });  
+
   it('should search alternative text', function () {
-    $('.selectric-input').val('alt banana').trigger('input');
+    select.find('option:eq(6)').attr('data-alt', 'alt blackberry');
+    select.selectric('refresh');
+    $('.selectric-input').val('alt blackberry').trigger('input');
     $('.selectric-items').find('.highlighted').click();
-    expect(select.val()).toBe('banana');
+    expect(select.val()).toBe('blackberry');
   });
 
   it('should search alternative text with separator', function () {
-    $('.selectric-input').val('altberry').trigger('input');
+    select.find('option:eq(6)').attr('data-alt', 'alt blackberry | another berry');
+    select.selectric('refresh');
+    $('.selectric-input').val('alt blackberry').trigger('input');
     $('.selectric-items').find('.highlighted').click();
-    expect(select.val()).toBe('bilberry');
+    expect(select.val()).toBe('blackberry');
   });
 
   it('should search alternative text with separator 2', function () {
+    select.find('option:eq(6)').attr('data-alt', 'alt blackberry | another berry');
+    select.selectric('refresh');
     $('.selectric-input').val('another berry').trigger('input');
     $('.selectric-items').find('.highlighted').click();
-    expect(select.val()).toBe('bilberry');
+    expect(select.val()).toBe('blackberry');
   });  
+
+  it('should skip blank alternative text', function () {
+    select.find('option:eq(6)').attr('data-alt', '');
+    select.selectric('refresh');
+    $('.selectric-input').val('a text that does not exist').trigger('input');
+    expect($('.selectric-items').find('.highlighted').length).toBe(0);
+  });    
 
   it('highlight() should return undefined if index is undefined', function () {
     expect(select.data('selectric').highlight(undefined)).toBe(undefined);

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -119,6 +119,13 @@ describe('basic suite', function() {
     expect($('.selectric-items').find('.highlighted').length).toBe(0);
   });    
 
+  it('should skip blank alternative text with separator', function () {
+    select.find('option:eq(6)').attr('data-alt', '|');
+    select.selectric('refresh');
+    $('.selectric-input').val('a text that does not exist').trigger('input');
+    expect($('.selectric-items').find('.highlighted').length).toBe(0);
+  });    
+
   it('highlight() should return undefined if index is undefined', function () {
     expect(select.data('selectric').highlight(undefined)).toBe(undefined);
   });

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -4,8 +4,8 @@
   <option value="loooooooooooooong-option">Loooooooooooooong option</option>
   <option value="apple">Apple</option>
   <option selected value="apricot">Apricot</option>
-  <option class="customOptionClass" value="banana"data-alt="alt banana">Banana</option>
-  <option value="bilberry" data-alt="altberry | another berry">Bilberry</option>
+  <option class="customOptionClass" value="banana">Banana</option>
+  <option value="bilberry">Bilberry</option>
   <option value="blackberry">Blackberry</option>
   <option value="blackcurrant">Blackcurrant</option>
   <option value="blueberry">Blueberry</option>

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -4,8 +4,8 @@
   <option value="loooooooooooooong-option">Loooooooooooooong option</option>
   <option value="apple">Apple</option>
   <option selected value="apricot">Apricot</option>
-  <option class="customOptionClass" value="banana">Banana</option>
-  <option value="bilberry">Bilberry</option>
+  <option class="customOptionClass" value="banana"data-alt="alt banana">Banana</option>
+  <option value="bilberry" data-alt="altberry | another berry">Bilberry</option>
   <option value="blackberry">Blackberry</option>
   <option value="blackcurrant">Blackcurrant</option>
   <option value="blueberry">Blueberry</option>


### PR DESCRIPTION
Extend the search with alternative texts for each option:

- attribute data-alt to define the alternative texts
- the character | could be used as separator for multiple texts for an option
 
 