### PR TITLE
Fix mouse wheel scroll-up not working

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -879,7 +879,7 @@
           /* istanbul ignore next */
           $doc.on('mousewheel' + eventNamespaceSuffix + ' DOMMouseScroll' + eventNamespaceSuffix, '.' + _this.classes.scroll, function(e) {
             var orgEvent = e.originalEvent;
-            var scrollTop = $(this).scrollTop();
+            var scrollTop = $(this).parent().scrollTop();
             var deltaY = 0;
 
             if ( 'detail'      in orgEvent ) { deltaY = orgEvent.detail * -1; }


### PR DESCRIPTION
This is a bugfix commit. Scrolling with the mouse wheel only works downwards, but not upwards in the open selectric panel. This is because the condition to prevent scrolling up when we're already at the top takes the position from the wrong element and it always thinks it's scrolled all the way up, preventing any further scroll upwards. This commit fixes it by taking the scroll position from the correct element, the parent.