### PR TITLE
Update the gulp-uglify config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,7 @@ gulp.task('js-min', function() {
   var pkg = getPackageJson();
 
   return gulp.src(['./src/jquery.selectric.js'])
-    .pipe($.uglify())
+    .pipe($.uglify({ output: { keep_quoted_props: true } }))
     .pipe($.header(bannerSmall, { pkg: pkg }))
     .pipe($.rename({ suffix: '.min' }))
     .pipe(gulp.dest('./public'))


### PR DESCRIPTION
Hello! The uglify file has remove the quote of property，so throw an error in IE 7. I suggest to modify the`keep_quoted_props` of uglify option to `true`. Thanks

![20171027194114](https://user-images.githubusercontent.com/8152848/32102509-3a61a958-bb4f-11e7-95f4-f300ebc0bc9a.jpg)
