### PR TITLE
Don't use Tab as select key

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -709,7 +709,7 @@
         _this.highlight(goToItem);
       }
 
-      // Tab / Enter / ESC
+      // Enter / ESC
       if ( isSelectKey && _this.state.opened ) {
         _this.select(idx);
 
@@ -1093,7 +1093,7 @@
     keys                 : {
       previous : [37, 38],                 // Left / Up
       next     : [39, 40],                 // Right / Down
-      select   : [9, 13, 27],              // Tab / Enter / Escape
+      select   : [13, 27],              // Enter / Escape
       open     : [13, 32, 37, 38, 39, 40], // Enter / Space / Left / Up / Right / Down
       close    : [9, 27]                   // Tab / Escape
     },


### PR DESCRIPTION
Use Tab as select key has 2 problems : 
1/ normal select : enter the select, use arrow to select an option, use TAB to go out the option is selected (this could be discussed but why not) then go back to the field use arrow to go to the selected option and use TAB to go out : the option is deselected. This is obviously not want the user want to do
2/ multiple select : the problem here is that the code assume that the selected option is the highlighted value but in case of multiple it is an array of indexes and then the select() code crash because it assume that only an index is given

I think that Enter/Space is enough for selection. Removing Tab from select keys remove these side effect and I feel the behaviour quite confortable