### PR TITLE
Performance: compute originalWidth conditionally

### DIFF
--- a/src/jquery.selectric.js
+++ b/src/jquery.selectric.js
@@ -269,10 +269,6 @@
     /** Activates the plugin */
     activate: function() {
       var _this = this;
-      var hiddenChildren = _this.elements.items.closest(':visible').children(':hidden').addClass(_this.classes.tempshow);
-      var originalWidth = _this.$element.width();
-
-      hiddenChildren.removeClass(_this.classes.tempshow);
 
       _this.utils.triggerCallback('BeforeActivate', _this);
 
@@ -284,8 +280,13 @@
         ])
       );
 
-      if ( _this.options.inheritOriginalWidth && originalWidth > 0 ) {
-        _this.elements.outerWrapper.width(originalWidth);
+      if ( _this.options.inheritOriginalWidth ) {
+        var hiddenChildren = _this.elements.items.closest(':visible').children(':hidden').addClass(_this.classes.tempshow);
+        var originalWidth = _this.$element.width();
+        hiddenChildren.removeClass(_this.classes.tempshow);
+        if ( originalWidth > 0 ) {
+          _this.elements.outerWrapper.width(originalWidth);
+        }
       }
 
       _this.unbindEvents();


### PR DESCRIPTION
Perform the expensive originalWidth calculation only when necessary for inheritOriginalWidth:

<img width="441" alt="Screenshot 2021-03-13 at 00 09 16" src="https://user-images.githubusercontent.com/782446/111008291-0d34e900-8391-11eb-96a5-fa96def56c80.png">
