### PR TITLE
Set jquery as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "type": "git",
     "url": "https://github.com/lcdsantos/jQuery-Selectric.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "jquery": "^3.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
jquery should only exist in one version and once instance if having a complex module structure selectric accidently creates a instance of it. NPM introduced to fix issues for this peerDependencies. Read more about them here: https://nodejs.org/es/blog/npm/peer-dependencies/